### PR TITLE
Fix auth token handling for Expediente IMT uploads

### DIFF
--- a/web/src/components/ExpedienteTab.jsx
+++ b/web/src/components/ExpedienteTab.jsx
@@ -121,12 +121,14 @@ export default function ExpedienteTab({ token }) {
         try {
             setBusy(true); setProgress(0);
             await uploadExpediente({
-                project_id: projectId,
-                stage_id: stageId,
-                deliverable_key: d.key,
+                projectId,
+                stageId,
+                deliverableKey: d.key,
                 file,
-                reason
-            }, token, p => setProgress(p));
+                reason,
+                token,
+                onProgress: (p) => setProgress(p),
+            });
             toast.success("Archivo subido");
             await refreshSnapshot();
         } catch (err) {


### PR DESCRIPTION
## Summary
- ensure Expediente IMT uploads send auth token and progress callback correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4fc6d6e6483318c9f4cc18a2b8618