### PR TITLE
feat: require admin approval to delete files

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { login, requestRegister } from "./api";
 import ProjectAdmin from "./ProjectAdmin";
 import RegistrationAdmin from "./RegistrationAdmin";
+import DeleteRequestsAdmin from "./DeleteRequestsAdmin";
 import toast from "react-hot-toast";
 import { LogOut, Upload, Settings2, ClipboardList } from "lucide-react";
 import ExpedienteTab from "./components/ExpedienteTab";
@@ -155,6 +156,7 @@ export default function App() {
                         ) : tab === "solicitudes" ? (
                             <div className="rounded-2xl border bg-white p-6 shadow-sm">
                                 <RegistrationAdmin token={token} />
+                                <DeleteRequestsAdmin token={token} />
                             </div>
                         ) : null}
                     </>

--- a/web/src/DeleteRequestsAdmin.jsx
+++ b/web/src/DeleteRequestsAdmin.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { listDeleteRequests, approveDeleteRequest } from "./api";
+
+export default function DeleteRequestsAdmin({ token }) {
+    const [items, setItems] = useState([]);
+
+    async function load() {
+        try {
+            const rows = await listDeleteRequests(token);
+            setItems(rows);
+        } catch (err) {
+            toast.error(err.message || "Error");
+        }
+    }
+
+    useEffect(() => {
+        load();
+    }, [token]);
+
+    async function approve(id) {
+        if (!window.confirm("¿Aprobar eliminación?")) return;
+        try {
+            await approveDeleteRequest(id, token);
+            toast.success("Eliminado");
+            await load();
+        } catch (err) {
+            toast.error(err.message || "Error");
+        }
+    }
+
+    return (
+        <div className="mt-8">
+            <h3 className="text-base font-semibold mb-4">Solicitudes de eliminación de archivos</h3>
+            <table className="min-w-full text-sm">
+                <thead>
+                    <tr className="border-b text-left">
+                        <th className="py-2 pr-3">Archivo</th>
+                        <th className="py-2 pr-3">Motivo</th>
+                        <th className="py-2 pr-3">Solicitante</th>
+                        <th className="py-2 pr-3">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {items.map((r) => (
+                        <tr key={r.id} className="border-b">
+                            <td className="py-2 pr-3">{r.file?.filename || "(archivo perdido)"}</td>
+                            <td className="py-2 pr-3">{r.reason}</td>
+                            <td className="py-2 pr-3">{r.requested_by}</td>
+                            <td className="py-2 pr-3">
+                                <button
+                                    type="button"
+                                    onClick={() => approve(r.id)}
+                                    className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                >
+                                    Aprobar
+                                </button>
+                            </td>
+                        </tr>
+                    ))}
+                    {items.length === 0 && (
+                        <tr>
+                            <td className="py-4 text-center text-slate-500" colSpan={4}>
+                                No hay solicitudes pendientes.
+                            </td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -130,6 +130,34 @@ export async function deleteFile(fileId, token) {
     return j;
 }
 
+export async function requestDeleteFile(fileId, reason, token) {
+    const r = await fetch(`${API}/files/${fileId}/request-delete`, {
+        method: "POST",
+        headers: { ...authHeaders(token), "Content-Type": "application/x-www-form-urlencoded" },
+        body: asForm({ reason }),
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "No se pudo solicitar la eliminación");
+    return j;
+}
+
+export async function listDeleteRequests(token) {
+    const r = await fetch(`${API}/file-delete-requests`, { headers: authHeaders(token) });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "Error listando solicitudes");
+    return j.items || [];
+}
+
+export async function approveDeleteRequest(reqId, token) {
+    const r = await fetch(`${API}/file-delete-requests/${reqId}/approve`, {
+        method: "POST",
+        headers: authHeaders(token),
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "Error aprobando solicitud");
+    return j;
+}
+
 // -------------- progreso de proyecto --------------
 export async function getProjectProgress(projectId, token) {
     const r = await fetch(`${API}/projects/${projectId}/progress`, {

--- a/web/src/components/ExpTecTab.jsx
+++ b/web/src/components/ExpTecTab.jsx
@@ -5,7 +5,7 @@ import {
     listFiles,
     uploadByCategory,
     downloadFileById,
-    deleteFile,
+    requestDeleteFile,
 } from "../api";
 
 function bytes(n) {
@@ -90,13 +90,14 @@ export default function ExpTecTab({ token }) {
     }
 
     async function onDelete(id) {
-        if (!window.confirm("¿Eliminar este archivo?")) return;
+        const reason = window.prompt("Motivo para eliminar este archivo:");
+        if (!reason || !reason.trim()) return;
         try {
-            await deleteFile(id, token);
-            await loadFiles(projectId);
+            await requestDeleteFile(id, reason, token);
+            alert("Solicitud enviada");
         } catch (err) {
             console.error(err);
-            alert(err.message || "Error eliminando archivo");
+            alert(err.message || "Error solicitando eliminación");
         }
     }
 

--- a/web/src/components/ExpedienteTab.jsx
+++ b/web/src/components/ExpedienteTab.jsx
@@ -7,7 +7,7 @@ import {
     getExpediente,
     uploadExpediente,
     downloadFileById,
-    deleteFile,
+    requestDeleteFile,
 } from "../api";
 
 
@@ -139,13 +139,14 @@ export default function ExpedienteTab({ token }) {
     }
 
     async function onDeleteFile(id) {
-        if (!window.confirm("¿Eliminar este archivo?")) return;
+        const reason = window.prompt("Motivo para eliminar este archivo:");
+        if (!reason || !reason.trim()) return;
         try {
-            await deleteFile(id, token);
-            await refreshSnapshot();
+            await requestDeleteFile(id, reason, token);
+            toast.success("Solicitud enviada");
         } catch (err) {
             console.error(err);
-            alert(err.message || "Error eliminando archivo");
+            alert(err.message || "Error solicitando eliminación");
         }
     }
 


### PR DESCRIPTION
## Summary
- add `FileDeleteRequest` model and endpoints to request and approve file deletions
- restrict direct file removal to admins
- add UI for users to request deletions with a reason and for admins to approve

## Testing
- `python -m py_compile app.py && echo 'py_compile success'`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5003a488883318d9d4bcc9523a9e2