### PR TITLE
feat: allow denying file delete requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 web/node_modules/
 web/dist/
+storage

--- a/backend/app.py
+++ b/backend/app.py
@@ -135,6 +135,18 @@ class RegistrationRequest(Base):
     decided_by = Column(Integer, ForeignKey("users.id"), nullable=True)
     want_create = Column(Boolean, nullable=False, server_default="false")
 
+
+class FileDeleteRequest(Base):
+    __tablename__ = "file_delete_requests"
+    id = Column(Integer, primary_key=True)
+    file_id = Column(Integer, ForeignKey("files.id"), nullable=False)
+    requested_by = Column(Integer, ForeignKey("users.id"), nullable=False)
+    reason = Column(Text, nullable=False)
+    status = Column(String(16), nullable=False, default="pending")  # pending|approved|rejected
+    requested_at = Column(DateTime, default=func.now())
+    decided_at = Column(DateTime, nullable=True)
+    decided_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+
 # ---- Wire del seeder (import tardío para evitar circular) ----
 _seed_project = None
 try:
@@ -399,6 +411,29 @@ def _expediente_snapshot(project_id: int, db: Session) -> dict:
                 if complete:
                     stage_done += 1
 
+            out_files = []
+            for f in files:
+                has_req = (
+                    db.query(FileDeleteRequest)
+                    .filter_by(file_id=f.id, status="pending")
+                    .first()
+                    is not None
+                )
+                out_files.append(
+                    {
+                        "id": f.id,
+                        "filename": f.filename,
+                        "size_bytes": f.size_bytes,
+                        "content_type": f.content_type,
+                        "uploaded_at": f.uploaded_at.isoformat() if f.uploaded_at else None,
+                        "uploaded_by": f.uploaded_by,
+                        "version": f.version,
+                        "is_active": f.is_active,
+                        "reason": f.reason,
+                        "pending_delete": has_req,
+                    }
+                )
+
             items.append({
                 "deliverable_id": spec.id,
                 "key": spec.key,
@@ -408,17 +443,7 @@ def _expediente_snapshot(project_id: int, db: Session) -> dict:
                 "allowed_ext": list(_parse_allowed_ext_csv(spec.allowed_ext)),
                 "optional_group": spec.optional_group,
                 "status": "completo" if complete else "faltante",
-                "files": [{
-                    "id": f.id,
-                    "filename": f.filename,
-                    "size_bytes": f.size_bytes,
-                    "content_type": f.content_type,
-                    "uploaded_at": f.uploaded_at.isoformat() if f.uploaded_at else None,
-                    "uploaded_by": f.uploaded_by,
-                    "version": f.version,
-                    "is_active": f.is_active,
-                    "reason": f.reason
-                } for f in files]
+                "files": out_files,
             })
 
         pct = round(100 * stage_done / stage_req, 1) if stage_req > 0 else 0.0
@@ -974,13 +999,11 @@ def download_file(
 def delete_file(
     file_id: int,
     db: Session = Depends(get_db),
-    current: User = Depends(get_current_user),
+    current: User = Depends(require_admin),
 ):
     rec = db.get(FileRecord, file_id)
     if not rec:
         raise HTTPException(404, "Archivo no encontrado")
-    # requiere rol de manager en el proyecto (o admin global)
-    ensure_member(db, current, rec.project_id, "manager")
     # eliminar del disco (si existe) y del registro
     try:
         p = Path(rec.path)
@@ -990,6 +1013,91 @@ def delete_file(
         # si falla borrar el archivo, seguimos con el registro para no bloquear
         pass
     db.delete(rec)
+    db.commit()
+    return {"ok": True}
+
+
+@app.post("/files/{file_id}/request-delete")
+def request_delete_file(
+    file_id: int,
+    reason: str = Form(...),
+    db: Session = Depends(get_db),
+    current: User = Depends(get_current_user),
+):
+    rec = db.get(FileRecord, file_id)
+    if not rec:
+        raise HTTPException(404, "Archivo no encontrado")
+    ensure_member(db, current, rec.project_id, "manager")
+    if db.query(FileDeleteRequest).filter_by(file_id=file_id, status="pending").first():
+        raise HTTPException(400, "Ya existe una solicitud pendiente")
+    req = FileDeleteRequest(file_id=file_id, requested_by=current.id, reason=reason.strip())
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+    return {"ok": True, "request_id": req.id}
+
+
+@app.get("/file-delete-requests")
+def list_delete_requests(
+    db: Session = Depends(get_db),
+    current: User = Depends(require_admin),
+):
+    q = db.query(FileDeleteRequest).filter(FileDeleteRequest.status == "pending").order_by(FileDeleteRequest.requested_at)
+    items = []
+    for r in q.all():
+        f = db.get(FileRecord, r.file_id)
+        proj = db.get(Project, f.project_id) if f else None
+        u = db.get(User, r.requested_by)
+        items.append(
+            {
+                "id": r.id,
+                "file": {"id": f.id, "filename": f.filename} if f else None,
+                "project": {"id": proj.id, "name": proj.name} if proj else None,
+                "reason": r.reason,
+                "requested_by": u.full_name or u.username if u else None,
+                "requested_at": r.requested_at.isoformat(),
+            }
+        )
+    return {"items": items}
+
+
+@app.post("/file-delete-requests/{req_id}/approve")
+def approve_delete_request(
+    req_id: int,
+    db: Session = Depends(get_db),
+    current: User = Depends(require_admin),
+):
+    req = db.get(FileDeleteRequest, req_id)
+    if not req or req.status != "pending":
+        raise HTTPException(404, "Solicitud no encontrada")
+    rec = db.get(FileRecord, req.file_id)
+    if rec:
+        try:
+            p = Path(rec.path)
+            if p.exists():
+                p.unlink()
+        except Exception:
+            pass
+        db.delete(rec)
+    req.status = "approved"
+    req.decided_at = func.now()
+    req.decided_by = current.id
+    db.commit()
+    return {"ok": True}
+
+
+@app.post("/file-delete-requests/{req_id}/reject")
+def reject_delete_request(
+    req_id: int,
+    db: Session = Depends(get_db),
+    current: User = Depends(require_admin),
+):
+    req = db.get(FileDeleteRequest, req_id)
+    if not req or req.status != "pending":
+        raise HTTPException(404, "Solicitud no encontrada")
+    req.status = "rejected"
+    req.decided_at = func.now()
+    req.decided_by = current.id
     db.commit()
     return {"ok": True}
 
@@ -1009,14 +1117,20 @@ def list_files(
         raise HTTPException(404, "Proyecto no existe")
     ensure_member(db, current, project_id, "viewer")
 
-    from sqlalchemy import or_
+    from sqlalchemy import or_, and_
     from sqlalchemy.orm import aliased
     U = aliased(User)
+    FDR = aliased(FileDeleteRequest)
 
     qset = (
-        db.query(FileRecord, Stage, U)
+        db.query(FileRecord, Stage, U, FDR)
         .join(Stage, Stage.id == FileRecord.stage_id, isouter=True)
         .join(U, U.id == FileRecord.uploaded_by, isouter=True)
+        .join(
+            FDR,
+            and_(FDR.file_id == FileRecord.id, FDR.status == "pending"),
+            isouter=True,
+        )
         .filter(FileRecord.project_id == project_id)
     )
     if stage_id:
@@ -1028,7 +1142,7 @@ def list_files(
     qset = qset.order_by(desc(FileRecord.uploaded_at)).limit(limit).offset(offset)
 
     items = []
-    for fr, st, u in qset.all():
+    for fr, st, u, dr in qset.all():
         rel_path = Path(fr.path).relative_to(FILES_ROOT / "projects" / proj.code)
         items.append({
             "id": fr.id,
@@ -1040,6 +1154,7 @@ def list_files(
             "uploaded_by": (u.username if u else None),
             "download_url": f"http://localhost:8000/download/{fr.id}",
             "path": str(rel_path),
+            "pending_delete": dr is not None,
         })
     return {"items": items, "limit": limit, "offset": offset}
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { login, requestRegister } from "./api";
 import ProjectAdmin from "./ProjectAdmin";
 import RegistrationAdmin from "./RegistrationAdmin";
+import DeleteRequestsAdmin from "./DeleteRequestsAdmin";
 import toast from "react-hot-toast";
 import { LogOut, Upload, Settings2, ClipboardList } from "lucide-react";
 import ExpedienteTab from "./components/ExpedienteTab";
@@ -155,6 +156,7 @@ export default function App() {
                         ) : tab === "solicitudes" ? (
                             <div className="rounded-2xl border bg-white p-6 shadow-sm">
                                 <RegistrationAdmin token={token} />
+                                <DeleteRequestsAdmin token={token} />
                             </div>
                         ) : null}
                     </>

--- a/web/src/DeleteRequestsAdmin.jsx
+++ b/web/src/DeleteRequestsAdmin.jsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { listDeleteRequests, approveDeleteRequest, rejectDeleteRequest } from "./api";
+
+export default function DeleteRequestsAdmin({ token }) {
+    const [items, setItems] = useState([]);
+
+    async function load() {
+        try {
+            const rows = await listDeleteRequests(token);
+            setItems(rows);
+        } catch (err) {
+            toast.error(err.message || "Error");
+        }
+    }
+
+    useEffect(() => {
+        load();
+    }, [token]);
+
+    async function approve(id) {
+        if (!window.confirm("¿Aprobar eliminación?")) return;
+        try {
+            await approveDeleteRequest(id, token);
+            toast.success("Eliminado");
+            await load();
+        } catch (err) {
+            toast.error(err.message || "Error");
+        }
+    }
+
+    async function reject(id) {
+        if (!window.confirm("¿Rechazar solicitud?")) return;
+        try {
+            await rejectDeleteRequest(id, token);
+            toast.success("Solicitud rechazada");
+            await load();
+        } catch (err) {
+            toast.error(err.message || "Error");
+        }
+    }
+
+    return (
+        <div className="mt-8">
+            <h3 className="text-base font-semibold mb-4">Solicitudes de eliminación de archivos</h3>
+            <table className="min-w-full text-sm">
+                <thead>
+                    <tr className="border-b text-left">
+                        <th className="py-2 pr-3">Archivo</th>
+                        <th className="py-2 pr-3">Proyecto</th>
+                        <th className="py-2 pr-3">Motivo</th>
+                        <th className="py-2 pr-3">Solicitante</th>
+                        <th className="py-2 pr-3">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {items.map((r) => (
+                        <tr key={r.id} className="border-b">
+                            <td className="py-2 pr-3">{r.file?.filename || "(archivo perdido)"}</td>
+                            <td className="py-2 pr-3">{r.project?.name || "(sin proyecto)"}</td>
+                            <td className="py-2 pr-3">{r.reason}</td>
+                            <td className="py-2 pr-3">{r.requested_by}</td>
+                            <td className="py-2 pr-3">
+                                <button
+                                    type="button"
+                                    onClick={() => approve(r.id)}
+                                    className="mr-2 rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                >
+                                    Aprobar
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => reject(r.id)}
+                                    className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                >
+                                    Denegar
+                                </button>
+                            </td>
+                        </tr>
+                    ))}
+                    {items.length === 0 && (
+                        <tr>
+                            <td className="py-4 text-center text-slate-500" colSpan={5}>
+                                No hay solicitudes pendientes.
+                            </td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -130,6 +130,56 @@ export async function deleteFile(fileId, token) {
     return j;
 }
 
+export async function requestDeleteFile(fileId, reason, token) {
+    const r = await fetch(`${API}/files/${fileId}/request-delete`, {
+        method: "POST",
+        headers: { ...authHeaders(token), "Content-Type": "application/x-www-form-urlencoded" },
+        body: asForm({ reason }),
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "No se pudo solicitar la eliminación");
+    return j;
+}
+
+export async function listDeleteRequests(token) {
+    const r = await fetch(`${API}/file-delete-requests`, { headers: authHeaders(token) });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "Error listando solicitudes");
+    return j.items || [];
+}
+
+export async function approveDeleteRequest(reqId, token) {
+    const r = await fetch(`${API}/file-delete-requests/${reqId}/approve`, {
+        method: "POST",
+        headers: { ...authHeaders(token), "Content-Type": "application/json" },
+        body: "{}",
+    });
+    let j = {};
+    try {
+        j = await r.json();
+    } catch {
+        /* ignore */
+    }
+    if (!r.ok) throw new Error(j.detail || "Error aprobando solicitud");
+    return j;
+}
+
+export async function rejectDeleteRequest(reqId, token) {
+    const r = await fetch(`${API}/file-delete-requests/${reqId}/reject`, {
+        method: "POST",
+        headers: { ...authHeaders(token), "Content-Type": "application/json" },
+        body: "{}",
+    });
+    let j = {};
+    try {
+        j = await r.json();
+    } catch {
+        /* ignore */
+    }
+    if (!r.ok) throw new Error(j.detail || "Error rechazando solicitud");
+    return j;
+}
+
 // -------------- progreso de proyecto --------------
 export async function getProjectProgress(projectId, token) {
     const r = await fetch(`${API}/projects/${projectId}/progress`, {

--- a/web/src/components/ExpTecTab.jsx
+++ b/web/src/components/ExpTecTab.jsx
@@ -5,7 +5,7 @@ import {
     listFiles,
     uploadByCategory,
     downloadFileById,
-    deleteFile,
+    requestDeleteFile,
 } from "../api";
 
 function bytes(n) {
@@ -90,13 +90,15 @@ export default function ExpTecTab({ token }) {
     }
 
     async function onDelete(id) {
-        if (!window.confirm("¿Eliminar este archivo?")) return;
+        const reason = window.prompt("Motivo para eliminar este archivo:");
+        if (!reason || !reason.trim()) return;
         try {
-            await deleteFile(id, token);
+            await requestDeleteFile(id, reason, token);
+            alert("Solicitud enviada");
             await loadFiles(projectId);
         } catch (err) {
             console.error(err);
-            alert(err.message || "Error eliminando archivo");
+            alert(err.message || "Error solicitando eliminación");
         }
     }
 
@@ -181,6 +183,9 @@ export default function ExpTecTab({ token }) {
                                                             <span className="text-slate-700 truncate">
                                                                 {f.filename} · {bytes(f.size_bytes)}
                                                             </span>
+                                                            {f.pending_delete && (
+                                                                <span className="text-xs text-red-600">(pendiente)</span>
+                                                            )}
                                                             <button
                                                                 type="button"
                                                                 onClick={() => downloadFileById(f.id, f.filename, token, { view: true })}
@@ -195,13 +200,17 @@ export default function ExpTecTab({ token }) {
                                                             >
                                                                 Descargar
                                                             </button>
-                                                            <button
-                                                                type="button"
-                                                                onClick={() => onDelete(f.id)}
-                                                                className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                            >
-                                                                Eliminar
-                                                            </button>
+                                                            {f.pending_delete ? (
+                                                                <span className="rounded-md border px-2 py-1 text-xs text-slate-500">Pendiente</span>
+                                                            ) : (
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => onDelete(f.id)}
+                                                                    className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                                                >
+                                                                    Eliminar
+                                                                </button>
+                                                            )}
                                                         </li>
                                                     ))}
                                                 </ul>

--- a/web/src/components/ExpedienteTab.jsx
+++ b/web/src/components/ExpedienteTab.jsx
@@ -7,7 +7,7 @@ import {
     getExpediente,
     uploadExpediente,
     downloadFileById,
-    deleteFile,
+    requestDeleteFile,
 } from "../api";
 
 
@@ -139,13 +139,15 @@ export default function ExpedienteTab({ token }) {
     }
 
     async function onDeleteFile(id) {
-        if (!window.confirm("¿Eliminar este archivo?")) return;
+        const reason = window.prompt("Motivo para eliminar este archivo:");
+        if (!reason || !reason.trim()) return;
         try {
-            await deleteFile(id, token);
+            await requestDeleteFile(id, reason, token);
+            toast.success("Solicitud enviada");
             await refreshSnapshot();
         } catch (err) {
             console.error(err);
-            alert(err.message || "Error eliminando archivo");
+            alert(err.message || "Error solicitando eliminación");
         }
     }
 
@@ -259,6 +261,9 @@ export default function ExpedienteTab({ token }) {
                                                                             <span className="text-slate-700">
                                                                                 v{f.version} · {f.filename} · {bytes(f.size_bytes)}
                                                                             </span>
+                                                                            {f.pending_delete && (
+                                                                                <span className="text-xs text-red-600">(pendiente)</span>
+                                                                            )}
                                                                             {f.is_active ? chip("Activo") : chip("Histórico")}
                                                                             <button
                                                                                 type="button"
@@ -276,14 +281,20 @@ export default function ExpedienteTab({ token }) {
                                                                             >
                                                                                 Descargar
                                                                             </button>
-                                                                            <button
-                                                                                type="button"
-                                                                                onClick={() => onDeleteFile(f.id)}
-                                                                                className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                                                title="Eliminar"
-                                                                            >
-                                                                                Eliminar
-                                                                            </button>
+                                                                            {f.pending_delete ? (
+                                                                                <span className="rounded-md border px-2 py-1 text-xs text-slate-500" title="Pendiente de eliminación">
+                                                                                    Pendiente
+                                                                                </span>
+                                                                            ) : (
+                                                                                <button
+                                                                                    type="button"
+                                                                                    onClick={() => onDeleteFile(f.id)}
+                                                                                    className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                                                                    title="Eliminar"
+                                                                                >
+                                                                                    Eliminar
+                                                                                </button>
+                                                                            )}
                                                                         </li>
                                                                     ))}
                                                                 </ul>


### PR DESCRIPTION
## Summary
- allow admins to deny file deletion requests and mark them rejected
- surface pending deletion status when listing files
- show pending tag in expediente views and add Denegar button for admins

## Testing
- `python -m py_compile app.py && echo 'py_compile success'`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5003a488883318d9d4bcc9523a9e2