### PR TITLE
Add read-only auditor user role

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -45,7 +45,7 @@ class User(Base):
     full_name = Column(String(255), nullable=False)
     email = Column(String(255), nullable=False)
     initials = Column(String(16), nullable=False)
-    role = Column(String(32), nullable=False, default="colaborador")  # admin | colaborador
+    role = Column(String(32), nullable=False, default="colaborador")  # admin | colaborador | auditor
     can_create_projects = Column(Boolean, nullable=False, server_default="false")
     created_at = Column(DateTime, default=func.now())
 
@@ -292,9 +292,16 @@ ROLE_ORDER = {"viewer": 0, "uploader": 1, "manager": 2, "admin": 3}
 def is_admin(u: User) -> bool:
     return u.role == "admin"
 
+def is_auditor(u: User) -> bool:
+    return u.role == "auditor"
+
 def ensure_member(db: Session, user: User, project_id: int, need: str = "viewer"):
     if is_admin(user):
         return
+    if is_auditor(user):
+        if need == "viewer":
+            return
+        raise HTTPException(403, "Permisos insuficientes")
     m = db.query(ProjectMember).filter_by(project_id=project_id, user_id=user.id).first()
     if not m:
         raise HTTPException(403, "No eres miembro de este proyecto")
@@ -715,7 +722,7 @@ def create_project(
 
 @app.get("/projects")
 def list_projects(db: Session = Depends(get_db), current: User = Depends(get_current_user)):
-    if is_admin(current):
+    if is_admin(current) or is_auditor(current):
         rows = (
             db.query(Project, ProjectMember.role)
             .outerjoin(ProjectMember, (ProjectMember.project_id == Project.id) & (ProjectMember.user_id == current.id))

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -144,11 +144,11 @@ export default function App() {
 
                         {tab === "expTec" ? (
                             <div className="rounded-2xl border bg-white p-6 shadow-sm">
-                                <ExpTecTab token={token} />
+                                <ExpTecTab token={token} readOnly={role === "auditor"} />
                             </div>
                         ) : tab === "expediente" ? (
                             <div className="rounded-2xl border bg-white p-6 shadow-sm">
-                                <ExpedienteTab token={token} />
+                                <ExpedienteTab token={token} readOnly={role === "auditor"} />
                             </div>
                         ) : tab === "proyectos" ? (
                             <div className="rounded-2xl border bg-white p-6 shadow-sm">

--- a/web/src/ProjectAdmin.jsx
+++ b/web/src/ProjectAdmin.jsx
@@ -145,7 +145,7 @@ export default function ProjectAdmin({ token, role, canCreate, initials }) {
     }
 
     const owned = projects.filter(p => p.is_owner);
-    const member = projects.filter(p => !p.is_owner);
+    const member = role === "auditor" ? projects : projects.filter(p => !p.is_owner);
 
     function roleLabel(r) {
         switch (r) {
@@ -249,14 +249,14 @@ export default function ProjectAdmin({ token, role, canCreate, initials }) {
                         )}
                         {member.length > 0 && (
                             <div>
-                                <h3 className="text-sm font-medium mb-2">Proyectos como miembro</h3>
+                                <h3 className="text-sm font-medium mb-2">{role === "auditor" ? "Todos los proyectos" : "Proyectos como miembro"}</h3>
                                 <div className="rounded-xl border overflow-hidden">
                                     <table className="w-full border-collapse text-sm">
                                         <thead className="bg-slate-100">
                                             <tr className="[&>th]:px-3 [&>th]:py-2 [&>th]:text-left">
                                                 <th>Código</th>
                                                 <th>Nombre</th>
-                                                <th>Mi rol</th>
+                                                {role !== "auditor" && <th>Mi rol</th>}
                                             </tr>
                                         </thead>
                                         <tbody className="[&>tr]:border-t [&>td]:px-3 [&>td]:py-2">
@@ -264,7 +264,7 @@ export default function ProjectAdmin({ token, role, canCreate, initials }) {
                                                 <tr key={p.id}>
                                                     <td>{p.code}</td>
                                                     <td>{p.name}</td>
-                                                    <td>{roleLabel(p.role)}</td>
+                                                    {role !== "auditor" && <td>{roleLabel(p.role)}</td>}
                                                 </tr>
                                             ))}
                                         </tbody>

--- a/web/src/RegistrationAdmin.jsx
+++ b/web/src/RegistrationAdmin.jsx
@@ -147,6 +147,7 @@ export default function RegistrationAdmin({ token }) {
                         className="mt-1 w-full rounded-lg border px-3 py-2 outline-none focus:ring-2 focus:ring-slate-300"
                     >
                         <option value="colaborador">colaborador</option>
+                        <option value="auditor">auditor</option>
                         <option value="admin">admin</option>
                     </select>
                 </div>
@@ -228,6 +229,7 @@ export default function RegistrationAdmin({ token }) {
                     <input value={newUser.initials} onChange={e=>setNewUser({...newUser, initials:e.target.value.toUpperCase()})} placeholder="Iniciales" className="rounded-lg border px-3 py-2 outline-none focus:ring-2 focus:ring-slate-300" />
                     <select value={newUser.role} onChange={e=>setNewUser({...newUser, role:e.target.value})} className="rounded-lg border px-3 py-2">
                         <option value="colaborador">colaborador</option>
+                        <option value="auditor">auditor</option>
                         <option value="admin">admin</option>
                     </select>
                     <label className="inline-flex items-center gap-2 text-sm">
@@ -263,6 +265,7 @@ export default function RegistrationAdmin({ token }) {
                                             <td>
                                                 <select value={u.role} onChange={e=>setUsers(us=>us.map(x=>x.id===u.id?{...x, role:e.target.value}:x))} className="border rounded px-2 py-1 w-32">
                                                     <option value="colaborador">colaborador</option>
+                                                    <option value="auditor">auditor</option>
                                                     <option value="admin">admin</option>
                                                 </select>
                                             </td>

--- a/web/src/components/ExpTecTab.jsx
+++ b/web/src/components/ExpTecTab.jsx
@@ -17,7 +17,7 @@ function bytes(n) {
     return n + " B";
 }
 
-export default function ExpTecTab({ token }) {
+export default function ExpTecTab({ token, readOnly = false }) {
     const [projects, setProjects] = useState([]);
     const [projectId, setProjectId] = useState("");
     const [tree, setTree] = useState({ sections: [] });
@@ -160,21 +160,25 @@ export default function ExpTecTab({ token }) {
                                         <tr key={r.mapKey} className="border-b align-top">
                                             <td className="py-2 pr-3">{r.title}</td>
                                             <td className="py-2 pr-3">
-                                                <button
-                                                    type="button"
-                                                    onClick={() => pickFile(r.mapKey)}
-                                                    className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                >
-                                                    Subir
-                                                </button>
-                                                <input
-                                                    type="file"
-                                                    className="hidden"
-                                                    ref={(el) => (fileInputs.current[r.mapKey] = el)}
-                                                    onChange={(e) =>
-                                                        onFile(e, r.sectionKey, r.categoryKey, r.subKey, r.mapKey)
-                                                    }
-                                                />
+                                                {!readOnly && (
+                                                    <>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => pickFile(r.mapKey)}
+                                                            className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                                        >
+                                                            Subir
+                                                        </button>
+                                                        <input
+                                                            type="file"
+                                                            className="hidden"
+                                                            ref={(el) => (fileInputs.current[r.mapKey] = el)}
+                                                            onChange={(e) =>
+                                                                onFile(e, r.sectionKey, r.categoryKey, r.subKey, r.mapKey)
+                                                            }
+                                                        />
+                                                    </>
+                                                )}
                                             </td>
                                             <td className="py-2 pr-3">
                                                 <ul className="space-y-1">
@@ -203,13 +207,15 @@ export default function ExpTecTab({ token }) {
                                                             {f.pending_delete ? (
                                                                 <span className="rounded-md border px-2 py-1 text-xs text-slate-500">Pendiente</span>
                                                             ) : (
-                                                                <button
-                                                                    type="button"
-                                                                    onClick={() => onDelete(f.id)}
-                                                                    className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                                >
-                                                                    Eliminar
-                                                                </button>
+                                                                !readOnly && (
+                                                                    <button
+                                                                        type="button"
+                                                                        onClick={() => onDelete(f.id)}
+                                                                        className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                                                    >
+                                                                        Eliminar
+                                                                    </button>
+                                                                )
                                                             )}
                                                         </li>
                                                     ))}

--- a/web/src/components/ExpedienteTab.jsx
+++ b/web/src/components/ExpedienteTab.jsx
@@ -35,7 +35,7 @@ function ProgressBar({ value }) {
     );
 }
 
-export default function ExpedienteTab({ token }) {
+export default function ExpedienteTab({ token, readOnly = false }) {
     const [projects, setProjects] = useState([]);
     const [projectId, setProjectId] = useState("");
     const [stages, setStages] = useState([]);
@@ -286,21 +286,24 @@ export default function ExpedienteTab({ token }) {
                                                                                     Pendiente
                                                                                 </span>
                                                                             ) : (
-                                                                                <button
-                                                                                    type="button"
-                                                                                    onClick={() => onDeleteFile(f.id)}
-                                                                                    className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                                                    title="Eliminar"
-                                                                                >
-                                                                                    Eliminar
-                                                                                </button>
+                                                                                !readOnly && (
+                                                                                    <button
+                                                                                        type="button"
+                                                                                        onClick={() => onDeleteFile(f.id)}
+                                                                                        className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                                                                        title="Eliminar"
+                                                                                    >
+                                                                                        Eliminar
+                                                                                    </button>
+                                                                                )
                                                                             )}
-                                                                        </li>
-                                                                    ))}
-                                                                </ul>
-                                                            )}
-                                                        </td>
-                                                        <td className="py-3 align-top">
+                                                                    </li>
+                                                                ))}
+                                                            </ul>
+                                                        )}
+                                                    </td>
+                                                    <td className="py-3 align-top">
+                                                        {!readOnly && (
                                                             <div className="flex items-center gap-2">
                                                                 <input
                                                                     ref={(el) => (fileInputs.current[d.key] = el)}
@@ -318,12 +321,13 @@ export default function ExpedienteTab({ token }) {
                                                                     {busy ? "Subiendo..." : hasActive && !d.multi ? "Reemplazar" : "Subir"}
                                                                 </button>
                                                             </div>
-                                                        </td>
-                                                    </tr>
-                                                );
-                                            })}
-                                        </tbody>
-                                    </table>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
                                 </div>
                                 {/* barra global de subida */}
                                 {busy && (


### PR DESCRIPTION
## Summary
- add new auditor role to backend with read-only project access
- allow auditors to view all projects without modifications
- update frontend to hide upload/delete actions and expose auditor role options

## Testing
- `python -m py_compile backend/app.py`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a54a4a2d9c833187ba72b77e6ea7d6