### PR TITLE
Allow uploading folders and custom subdirectories

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -333,7 +333,13 @@ def get_project_schema(ptype: str) -> Dict:
         raise HTTPException(500, "Esquema de carpetas no configurado para el tipo")
     return sch
 
-def resolve_folder_path(proj: Project, section_key: str, category_key: str, subcategory_key: Optional[str] = None) -> Path:
+def resolve_folder_path(
+    proj: Project,
+    section_key: str,
+    category_key: str,
+    subcategory_key: Optional[str] = None,
+    subpath: Optional[str] = None,
+) -> Path:
     sch = get_project_schema(proj.type)
     section = next((s for s in sch["sections"] if s["key"] == section_key), None)
     if not section:
@@ -348,6 +354,11 @@ def resolve_folder_path(proj: Project, section_key: str, category_key: str, subc
         if not sub:
             raise HTTPException(400, "Subcategoría inválida")
         parts.append(sub["folder"])
+    if subpath:
+        for part in Path(subpath).parts:
+            cleaned = safe_folder(part)
+            if cleaned:
+                parts.append(cleaned)
     parts.append(datetime.utcnow().strftime("%Y-%m-%d"))
     return FILES_ROOT / "projects" / Path("/".join(parts))
 
@@ -1178,6 +1189,7 @@ def upload_file(
     section_key: Optional[str] = Form(None),
     category_key: Optional[str] = Form(None),
     subcategory_key: Optional[str] = Form(None),
+    subpath: Optional[str] = Form(None),
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
     current: User = Depends(get_current_user),
@@ -1194,7 +1206,8 @@ def upload_file(
             proj,
             section_key.strip(),
             category_key.strip(),
-            subcategory_key.strip() if subcategory_key else None
+            subcategory_key.strip() if subcategory_key else None,
+            subpath.strip() if subpath else None,
         )
         stage_fk = None
     else:

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -95,12 +95,22 @@ export function uploadExpedienteLegacy(projectId, stageId, file, token, _subfold
     return xhrUpload(`${API}/upload`, fd, token, onProgress);
 }
 
-export function uploadByCategory(projectId, sectionKey, categoryKey, subcategoryKey, file, token, onProgress) {
+export function uploadByCategory(
+    projectId,
+    sectionKey,
+    categoryKey,
+    subcategoryKey,
+    file,
+    token,
+    onProgress,
+    subpath,
+) {
     const fd = new FormData();
     fd.append("project_id", projectId);
     fd.append("section_key", sectionKey);
     fd.append("category_key", categoryKey);
     if (subcategoryKey) fd.append("subcategory_key", subcategoryKey);
+    if (subpath) fd.append("subpath", subpath);
     fd.append("file", file);
     return xhrUpload(`${API}/upload`, fd, token, onProgress);
 }


### PR DESCRIPTION
## Summary
- support nested subfolders for technical file uploads
- enable uploading multiple files or entire folders from the web UI
- show relative subpaths when listing technical files

## Testing
- `cd backend && pytest`
- `cd ../web && npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a60589670c8331bc2e9e82c1ae4c24