### PR TITLE
Add directory tree interface with subfolder uploads

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -95,12 +95,22 @@ export function uploadExpedienteLegacy(projectId, stageId, file, token, _subfold
     return xhrUpload(`${API}/upload`, fd, token, onProgress);
 }
 
-export function uploadByCategory(projectId, sectionKey, categoryKey, subcategoryKey, file, token, onProgress) {
+export function uploadByCategory(
+    projectId,
+    sectionKey,
+    categoryKey,
+    subcategoryKey,
+    file,
+    token,
+    subpath,
+    onProgress
+) {
     const fd = new FormData();
     fd.append("project_id", projectId);
     fd.append("section_key", sectionKey);
     fd.append("category_key", categoryKey);
     if (subcategoryKey) fd.append("subcategory_key", subcategoryKey);
+    if (subpath) fd.append("subpath", subpath);
     fd.append("file", file);
     return xhrUpload(`${API}/upload`, fd, token, onProgress);
 }

--- a/web/src/components/ExpTecTab.jsx
+++ b/web/src/components/ExpTecTab.jsx
@@ -20,9 +20,11 @@ function bytes(n) {
 export default function ExpTecTab({ token, readOnly = false }) {
     const [projects, setProjects] = useState([]);
     const [projectId, setProjectId] = useState("");
-    const [tree, setTree] = useState({ sections: [] });
-    const [filesMap, setFilesMap] = useState({});
+    const [schema, setSchema] = useState({ sections: [] });
+    const [fileTree, setFileTree] = useState({});
     const fileInputs = useRef({});
+    const dirInputs = useRef({});
+    const nodeMap = useRef({});
 
     useEffect(() => {
         (async () => {
@@ -42,50 +44,163 @@ export default function ExpTecTab({ token, readOnly = false }) {
         (async () => {
             try {
                 const t = await getCategoryTree(projectId, token);
-                setTree(t);
-                await loadFiles(projectId);
+                setSchema(t);
+                await loadFiles(projectId, t);
             } catch (err) {
                 console.error(err);
             }
         })();
     }, [projectId, token]);
 
-    async function loadFiles(pid) {
+    function buildBaseTree(sch) {
+        const root = {};
+        sch.sections.forEach((sec) => {
+            const secNode = {
+                name: sec.folder,
+                sectionKey: sec.key,
+                categoryKey: null,
+                subcategoryKey: null,
+                subpath: "",
+                pathKey: sec.key,
+                children: {},
+            };
+            root[sec.folder] = secNode;
+            sec.categories.forEach((cat) => {
+                const catNode = {
+                    name: cat.folder,
+                    sectionKey: sec.key,
+                    categoryKey: cat.key,
+                    subcategoryKey: null,
+                    subpath: "",
+                    pathKey: [sec.key, cat.key].join("/"),
+                    children: {},
+                };
+                secNode.children[cat.folder] = catNode;
+                (cat.children || []).forEach((sub) => {
+                    const subNode = {
+                        name: sub.folder,
+                        sectionKey: sec.key,
+                        categoryKey: cat.key,
+                        subcategoryKey: sub.key,
+                        subpath: "",
+                        pathKey: [sec.key, cat.key, sub.key].join("/"),
+                        children: {},
+                    };
+                    catNode.children[sub.folder] = subNode;
+                });
+            });
+        });
+        return root;
+    }
+
+    async function loadFiles(pid, currSchema = schema) {
         try {
             const items = await listFiles(pid, {}, token);
-            const map = {};
+            const base = buildBaseTree(currSchema);
             for (const f of items) {
-                if (f.stage) continue; // solo info técnica
+                if (f.stage) continue;
                 if (!f.path) continue;
                 const parts = f.path.split("/");
                 const section = parts[0];
                 const category = parts[1];
-                let sub = null;
-                if (parts.length > 4) sub = parts[2];
-                const key = [section, category, sub].filter(Boolean).join("/");
-                if (!map[key]) map[key] = [];
-                map[key].push(f);
+                const dateIdx = parts.length - 2;
+                let rest = parts.slice(2, dateIdx);
+                let node = base[section]?.children?.[category];
+                if (!node) continue;
+                if (rest.length && node.children[rest[0]] && node.children[rest[0]].subcategoryKey) {
+                    node = node.children[rest[0]];
+                    rest = rest.slice(1);
+                }
+                for (const seg of rest) {
+                    const newSub = node.subpath ? `${node.subpath}/${seg}` : seg;
+                    if (!node.children[seg]) {
+                        node.children[seg] = {
+                            name: seg,
+                            sectionKey: node.sectionKey,
+                            categoryKey: node.categoryKey,
+                            subcategoryKey: node.subcategoryKey,
+                            subpath: newSub,
+                            pathKey: [node.sectionKey, node.categoryKey, node.subcategoryKey, newSub]
+                                .filter(Boolean)
+                                .join("/"),
+                            children: {},
+                        };
+                    }
+                    node = node.children[seg];
+                }
+                node.files = node.files || [];
+                node.files.push(f);
             }
-            setFilesMap(map);
+            nodeMap.current = {};
+            function register(n) {
+                nodeMap.current[n.pathKey] = n;
+                Object.values(n.children).forEach(register);
+            }
+            Object.values(base).forEach(register);
+            setFileTree(base);
         } catch (err) {
             console.error(err);
         }
     }
 
-    function pickFile(key) {
+    function pickFiles(key) {
         fileInputs.current[key]?.click();
     }
 
-    async function onFile(e, secKey, catKey, subKey, key) {
-        const file = e.target.files?.[0];
+    function pickDir(key) {
+        dirInputs.current[key]?.click();
+    }
+
+    async function onFiles(e, key) {
+        const node = nodeMap.current[key];
+        const files = Array.from(e.target.files || []);
         e.target.value = "";
-        if (!file) return;
+        if (!files.length) return;
         try {
-            await uploadByCategory(projectId, secKey, catKey, subKey, file, token);
+            for (const file of files) {
+                await uploadByCategory(
+                    projectId,
+                    node.sectionKey,
+                    node.categoryKey,
+                    node.subcategoryKey,
+                    file,
+                    token,
+                    node.subpath,
+                    undefined
+                );
+            }
             await loadFiles(projectId);
         } catch (err) {
             console.error(err);
             alert(err.message || "Error subiendo archivo");
+        }
+    }
+
+    async function onDir(e, key) {
+        const node = nodeMap.current[key];
+        const files = Array.from(e.target.files || []);
+        e.target.value = "";
+        if (!files.length) return;
+        try {
+            for (const file of files) {
+                const rel = file.webkitRelativePath.split("/").slice(1);
+                const inner = rel.slice(0, -1).join("/");
+                const sp = node.subpath ? [node.subpath, inner].filter(Boolean).join("/") : inner;
+                await uploadByCategory(
+                    projectId,
+                    node.sectionKey,
+                    node.categoryKey,
+                    node.subcategoryKey,
+                    file,
+                    token,
+                    sp,
+                    undefined
+                );
+            }
+            await loadFiles(projectId);
+        } catch (err) {
+            console.error(err);
+            alert(err.message || "Error subiendo carpeta");
         }
     }
 
@@ -100,6 +215,93 @@ export default function ExpTecTab({ token, readOnly = false }) {
             console.error(err);
             alert(err.message || "Error solicitando eliminación");
         }
+    }
+
+    function renderNode(node) {
+        const dirs = Object.values(node.children || {});
+        return (
+            <li key={node.pathKey} className="ml-2">
+                <div className="flex items-center gap-2">
+                    <span className="font-medium">{node.name}</span>
+                    {node.categoryKey && (
+                        <>
+                            <button
+                                type="button"
+                                onClick={() => pickFiles(node.pathKey)}
+                                className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                            >
+                                Subir archivos
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => pickDir(node.pathKey)}
+                                className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                            >
+                                Subir carpeta
+                            </button>
+                            <input
+                                type="file"
+                                multiple
+                                className="hidden"
+                                ref={(el) => (fileInputs.current[node.pathKey] = el)}
+                                onChange={(e) => onFiles(e, node.pathKey)}
+                            />
+                            <input
+                                type="file"
+                                multiple
+                                webkitdirectory="true"
+                                directory=""
+                                className="hidden"
+                                ref={(el) => (dirInputs.current[node.pathKey] = el)}
+                                onChange={(e) => onDir(e, node.pathKey)}
+                            />
+                        </>
+                    )}
+                </div>
+                <ul className="ml-4 space-y-1">
+                    {dirs.map((d) => renderNode(d))}
+                    {(node.files || []).map((f) => (
+                        <li key={f.id} className="flex items-center gap-2">
+                            <span className="text-slate-700 truncate">
+                                {f.filename} · {bytes(f.size_bytes)}
+                            </span>
+                            {f.pending_delete && (
+                                <span className="text-xs text-red-600">(pendiente)</span>
+                            )}
+                            <button
+                                type="button"
+                                onClick={() => downloadFileById(f.id, f.filename, token, { view: true })}
+                                className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                            >
+                                Ver
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => downloadFileById(f.id, f.filename, token)}
+                                className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                            >
+                                Descargar
+                            </button>
+                            {f.pending_delete ? (
+                                <span className="rounded-md border px-2 py-1 text-xs text-slate-500">
+                                    Pendiente
+                                </span>
+                            ) : (
+                                !readOnly && (
+                                    <button
+                                        type="button"
+                                        onClick={() => onDelete(f.id)}
+                                        className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                    >
+                                        Eliminar
+                                    </button>
+                                )
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            </li>
+        );
     }
 
     return (
@@ -120,115 +322,9 @@ export default function ExpTecTab({ token, readOnly = false }) {
                 </select>
             </div>
 
-            {tree.sections.map((sec) => {
-                const rows = [];
-                sec.categories.forEach((cat) => {
-                    if (cat.children && cat.children.length) {
-                        cat.children.forEach((sub) => {
-                            rows.push({
-                                sectionKey: sec.key,
-                                categoryKey: cat.key,
-                                subKey: sub.key,
-                                title: `${cat.folder} / ${sub.folder}`,
-                                mapKey: [sec.folder, cat.folder, sub.folder].join("/"),
-                            });
-                        });
-                    } else {
-                        rows.push({
-                            sectionKey: sec.key,
-                            categoryKey: cat.key,
-                            subKey: null,
-                            title: cat.folder,
-                            mapKey: [sec.folder, cat.folder].join("/"),
-                        });
-                    }
-                });
-                return (
-                    <div key={sec.key} className="mt-4">
-                        <h4 className="text-sm font-semibold mb-2">{sec.folder}</h4>
-                        <div className="overflow-x-auto">
-                            <table className="min-w-full text-sm">
-                                <thead>
-                                    <tr className="border-b text-left">
-                                        <th className="py-2 pr-3">Categoría</th>
-                                        <th className="py-2 pr-3">Acciones</th>
-                                        <th className="py-2 pr-3">Archivos</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {rows.map((r) => (
-                                        <tr key={r.mapKey} className="border-b align-top">
-                                            <td className="py-2 pr-3">{r.title}</td>
-                                            <td className="py-2 pr-3">
-                                                {!readOnly && (
-                                                    <>
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => pickFile(r.mapKey)}
-                                                            className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                        >
-                                                            Subir
-                                                        </button>
-                                                        <input
-                                                            type="file"
-                                                            className="hidden"
-                                                            ref={(el) => (fileInputs.current[r.mapKey] = el)}
-                                                            onChange={(e) =>
-                                                                onFile(e, r.sectionKey, r.categoryKey, r.subKey, r.mapKey)
-                                                            }
-                                                        />
-                                                    </>
-                                                )}
-                                            </td>
-                                            <td className="py-2 pr-3">
-                                                <ul className="space-y-1">
-                                                    {(filesMap[r.mapKey] || []).map((f) => (
-                                                        <li key={f.id} className="flex items-center gap-2">
-                                                            <span className="text-slate-700 truncate">
-                                                                {f.filename} · {bytes(f.size_bytes)}
-                                                            </span>
-                                                            {f.pending_delete && (
-                                                                <span className="text-xs text-red-600">(pendiente)</span>
-                                                            )}
-                                                            <button
-                                                                type="button"
-                                                                onClick={() => downloadFileById(f.id, f.filename, token, { view: true })}
-                                                                className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                            >
-                                                                Ver
-                                                            </button>
-                                                            <button
-                                                                type="button"
-                                                                onClick={() => downloadFileById(f.id, f.filename, token)}
-                                                                className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                            >
-                                                                Descargar
-                                                            </button>
-                                                            {f.pending_delete ? (
-                                                                <span className="rounded-md border px-2 py-1 text-xs text-slate-500">Pendiente</span>
-                                                            ) : (
-                                                                !readOnly && (
-                                                                    <button
-                                                                        type="button"
-                                                                        onClick={() => onDelete(f.id)}
-                                                                        className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
-                                                                    >
-                                                                        Eliminar
-                                                                    </button>
-                                                                )
-                                                            )}
-                                                        </li>
-                                                    ))}
-                                                </ul>
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                );
-            })}
+            <ul className="space-y-1">
+                {Object.values(fileTree).map((sec) => renderNode(sec))}
+            </ul>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- support nested subdirectories in backend upload endpoint
- enable subpath-aware uploads from web client and show directory tree like Nextcloud

## Testing
- `cd backend && pytest`
- `cd ../web && npm test` (fails: Missing script "test")
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a60589670c8331bc2e9e82c1ae4c24