### PR TITLE
fix: handle windows paths for folder uploads

### DIFF
--- a/web/src/components/ExpTecTab.jsx
+++ b/web/src/components/ExpTecTab.jsx
@@ -182,7 +182,13 @@ export default function ExpTecTab({ token, readOnly = false }) {
         if (!files.length) return;
         try {
             for (const file of files) {
-                const rel = file.webkitRelativePath.split("/").slice(1);
+                // webkitRelativePath usa "/" en la mayoría de navegadores, pero
+                // algunos entornos (especialmente en Windows) pueden reportar
+                // separadores "\". Para asegurar compatibilidad dividimos por
+                // ambos y removemos la carpeta raíz seleccionada.
+                const rel = (file.webkitRelativePath || "")
+                    .split(/[\\\/]+/)
+                    .slice(1);
                 const inner = rel.slice(0, -1).join("/");
                 const sp = node.subpath ? [node.subpath, inner].filter(Boolean).join("/") : inner;
                 await uploadByCategory(


### PR DESCRIPTION
## Summary
- ensure ExpTec folder uploads handle Windows path separators

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a625aa6d8c8331ba2770e8f7c6b19c