### PR TITLE
Remove date subfolders from file storage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,5 @@
+# Backend
+
+## Estructura de almacenamiento de archivos
+
+Los archivos se guardan dentro de `FILES_ROOT/projects/<codigo_de_proyecto>/...` sin crear una subcarpeta por fecha. La fecha de carga se obtiene del campo `uploaded_at` registrado en la base de datos.

--- a/web/src/components/ExpTecTab.jsx
+++ b/web/src/components/ExpTecTab.jsx
@@ -103,8 +103,8 @@ export default function ExpTecTab({ token, readOnly = false }) {
                 const parts = f.path.split("/");
                 const section = parts[0];
                 const category = parts[1];
-                const dateIdx = parts.length - 2;
-                let rest = parts.slice(2, dateIdx);
+                // La ruta ya no incluye subcarpeta por fecha; el índice final corresponde al archivo
+                let rest = parts.slice(2, parts.length - 1);
                 let node = base[section]?.children?.[category];
                 if (!node) continue;
                 if (rest.length && node.children[rest[0]] && node.children[rest[0]].subcategoryKey) {
@@ -268,7 +268,7 @@ export default function ExpTecTab({ token, readOnly = false }) {
                     {(node.files || []).map((f) => (
                         <li key={f.id} className="flex items-center gap-2">
                             <span className="text-slate-700 truncate">
-                                {f.filename} · {bytes(f.size_bytes)}
+                                {f.filename} · {bytes(f.size_bytes)} · {new Date(f.uploaded_at).toLocaleDateString()}
                             </span>
                             {f.pending_delete && (
                                 <span className="text-xs text-red-600">(pendiente)</span>

--- a/web/src/components/ExpedienteTab.jsx
+++ b/web/src/components/ExpedienteTab.jsx
@@ -259,7 +259,7 @@ export default function ExpedienteTab({ token, readOnly = false }) {
                                                                     {d.files.map((f) => (
                                                                         <li key={f.id} className="flex items-center gap-2">
                                                                             <span className="text-slate-700">
-                                                                                v{f.version} · {f.filename} · {bytes(f.size_bytes)}
+                                                                                v{f.version} · {f.filename} · {bytes(f.size_bytes)} · {new Date(f.uploaded_at).toLocaleDateString()}
                                                                             </span>
                                                                             {f.pending_delete && (
                                                                                 <span className="text-xs text-red-600">(pendiente)</span>


### PR DESCRIPTION
## Summary
- store uploads without date subfolder across backend helpers
- update frontend listings to rely on uploaded_at and display date
- document new storage layout without daily directories

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a62bcb882c83318514f4d258b42285