### PR TITLE
feat: add file preview modal with metadata and icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 storage
+node_modules/
+dist/


### PR DESCRIPTION
## Summary
- show `uploaded_by`, `version` and `content_type` fields in file list
- preview files in modal dialog instead of downloading on view
- display icons based on file extension

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a64b4106e88331a0c8cd3f52a015ba