### PR TITLE
feat: bulk file actions and endpoints

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -151,6 +151,36 @@ export async function requestDeleteFile(fileId, reason, token) {
     return j;
 }
 
+export async function bulkDownloadFiles(projectId, ids, token) {
+    const r = await fetch(`${API}/projects/${projectId}/files/bulk-download`, {
+        method: "POST",
+        headers: { ...authHeaders(token), "Content-Type": "application/json" },
+        body: JSON.stringify({ ids }),
+    });
+    if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        throw new Error(j.detail || "Error descargando archivos");
+    }
+    const blob = await r.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "archivos.zip";
+    a.click();
+    window.URL.revokeObjectURL(url);
+}
+
+export async function bulkRequestDelete(projectId, ids, reason, token) {
+    const r = await fetch(`${API}/projects/${projectId}/files/bulk-delete`, {
+        method: "POST",
+        headers: { ...authHeaders(token), "Content-Type": "application/json" },
+        body: JSON.stringify({ ids, reason }),
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "No se pudo solicitar la eliminación");
+    return j;
+}
+
 export async function listDeleteRequests(token) {
     const r = await fetch(`${API}/file-delete-requests`, { headers: authHeaders(token) });
     const j = await r.json();


### PR DESCRIPTION
## Summary
- add bulk download and delete functions and action bar to file tree
- support zip export and bulk delete on server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6500bcab88331a226c5dc062e084d