### PR TITLE
feat(web): add production Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,20 @@
+# web/Dockerfile
+
+# Stage 1: build the application
+FROM node:20-alpine AS build
+WORKDIR /app
+
+# Install dependencies (use cache efficiently)
+COPY package.json package-lock.json* ./
+RUN npm ci || npm i
+
+# Copy source and build
+COPY . .
+RUN npm run build
+
+# Stage 2: serve with nginx
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+USER 101
+HEALTHCHECK CMD wget -qO- http://localhost/ || exit 1


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for building with Node and serving via Nginx
- serve built `dist` on port 80 with non-root user and healthcheck

## Testing
- `npm run build`
- `docker build -t form-web -f web/Dockerfile web` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68ae833fd4f48331b84837087b0df9a9