### PR TITLE
docs: add docker usage section and project metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Unreleased]
+- Initial release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contribuir
+
+1. Haz un fork del repositorio.
+2. Crea una rama para tu cambio (`git checkout -b mi-cambio`).
+3. Asegúrate de que los tests pasan.
+4. Envía un pull request.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Form Platform
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,47 @@
 # Form Platform
 
-## Configuration
+## Configuración
 
-Copy the example environment file and adjust values as needed:
+Copia el archivo de variables de entorno de ejemplo y ajusta los valores según sea necesario:
 
 ```bash
 cp .env.example .env
+```
+
+## Ejecutar con Docker/Compose
+
+### Variables de entorno requeridas
+
+| Variable              | Descripción                                      |
+|-----------------------|--------------------------------------------------|
+| `POSTGRES_DB`         | Nombre de la base de datos de Postgres           |
+| `POSTGRES_USER`       | Usuario de Postgres                              |
+| `POSTGRES_PASSWORD`   | Contraseña de Postgres                           |
+| `API_JWT_SECRET`      | Clave para firmar los tokens JWT                 |
+| `MAX_FILE_MB`         | Tamaño máximo permitido para los archivos (MB)   |
+| `ALLOWED_EXT`         | Extensiones de archivo permitidas                |
+| `AUTOSEED_ENABLE`     | Precarga datos en la base de datos al iniciar    |
+| `AUTOSNAPSHOT_ON_UPLOAD` | Genera un snapshot al subir un archivo        |
+
+### Puertos expuestos
+
+- `5432` – Base de datos Postgres
+- `8000` – API (FastAPI)
+- `5173` – Interfaz web (Vite)
+
+### Volúmenes opcionales
+
+- `pgdata` – Persistencia de datos de Postgres
+- `./storage:/data` – Archivos subidos
+- `./backend:/app` y `./web:/app` – Código fuente montado para desarrollo
+- `web_node_modules` – Dependencias de Node.js
+
+### Ejemplos de uso
+
+```bash
+# Ejecutar solo la API
+docker run --env-file .env -p 8000:8000 -v $(pwd)/storage:/data form-platform-api
+
+# Levantar todos los servicios con Compose
+docker compose up --build
 ```


### PR DESCRIPTION
## Summary
- document how to run the stack with Docker and Compose
- add repository metadata files: LICENSE, CHANGELOG and CONTRIBUTING

## Testing
- `python -m py_compile backend/app.py backend/seed_deliverables.py`
- `cd web && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae84f6a29483319a41f8e31d40964a