### PR TITLE
feat: use multi-stage backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,19 +1,43 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1.4
+
+FROM python:3.11-slim AS builder
 
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-# Dependencias del sistema mínimas (libffi para bcrypt)
+# Dependencias para compilar paquetes (libffi para bcrypt)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential libffi-dev curl && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --user -r requirements.txt
 
 COPY . .
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH=/home/app/.local/bin:$PATH
+
+# Dependencias mínimas de runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libffi-dev curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Crear usuario sin privilegios
+RUN useradd -m app
+
+COPY --from=builder --chown=app:app /root/.local /home/app/.local
+COPY --from=builder --chown=app:app /app /app
+
+USER app
 
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=3s --retries=3 CMD curl -f http://localhost:8000/health || exit 1


### PR DESCRIPTION
## Summary
- switch backend to multi-stage Dockerfile with builder cache
- create non-root app user and set PATH

## Testing
- `pytest`
- `docker build backend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8aa9bb288331ab48c7c7487e5106