### PR TITLE
Add intervals and retries to web Dockerfile healthcheck

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,4 +21,4 @@ FROM nginx:1.27.2-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 USER 101
-HEALTHCHECK CMD wget -qO- http://localhost/ || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 CMD wget -qO- http://localhost/ || exit 1


### PR DESCRIPTION
## Summary
- replace web service healthcheck with wget command including interval, timeout, and retries

## Testing
- `docker build -t test-web web` *(fails: command not found: docker)*
- `cd web && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae9116d07c833199d59f621e3d076f