### PR TITLE
chore: bump Postgres to 16.4 and document patch updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ cp .env.example .env
 - `./backend:/app` y `./web:/app` – Código fuente montado para desarrollo
 - `web_node_modules` – Dependencias de Node.js
 
+### Actualizaciones de parches
+
+Actualiza periódicamente las versiones de parche de las imágenes utilizadas para obtener las últimas correcciones de seguridad. Por ejemplo, usa `postgres:16.4` en lugar de `postgres:16`.
+
 ### Ejemplos de uso
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: postgres:16.4
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}


### PR DESCRIPTION
## Summary
- use Postgres 16.4 image
- note periodic patch updates in documentation

## Testing
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ae918c0cd0833181e1da9a5820e24f