### PR TITLE
Add health check endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -515,6 +515,11 @@ def on_startup():
     create_db()
     safe_migrate()
 
+
+@app.get("/health", status_code=200)
+def health():
+    return {"status": "ok"}
+
 # -------- Auth --------
 @app.post("/auth/register")
 def register(

--- a/backend/test_health.py
+++ b/backend/test_health.py
@@ -1,0 +1,18 @@
+import os
+
+# Ensure environment variables required by settings are set before importing app
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("JWT_SECRET", "testsecret")
+
+from fastapi.testclient import TestClient
+from app import app
+
+app.router.on_startup.clear()
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `/health` endpoint for quick service status checks
- cover health endpoint with new test

## Testing
- `PYTHONPATH=backend pytest backend/test_health.py -q`
- `curl -i http://localhost:8000/health`


------
https://chatgpt.com/codex/tasks/task_e_68ae94685a6083319f48cfb943f5c6fe