### PR TITLE
chore: refine dockerignore patterns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ Dockerfile*
 **/node_modules
 __pycache__
 *.pyc
+**/.pytest_cache
 
 # Build outputs and tests
 dist
@@ -27,3 +28,9 @@ web/build
 
 # Logs
 *.log
+
+# OS files
+*.DS_Store
+
+# IDE settings
+.vscode

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -5,6 +5,7 @@
 # Python caches and bytecode
 __pycache__
 *.pyc
+**/.pytest_cache
 
 # Virtual environments
 venv
@@ -17,3 +18,7 @@ coverage
 
 # Logs
 *.log
+
+# IDE and system files
+.vscode
+*.DS_Store

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -10,6 +10,11 @@ build
 # Tests
 tests
 coverage
+**/.pytest_cache
 
 # Logs
 *.log
+
+# IDE and system files
+.vscode
+*.DS_Store


### PR DESCRIPTION
## Summary
- ignore editor settings and OS files in Docker contexts
- exclude pytest caches across root, backend and web builds

## Testing
- `tar -cf - --exclude-from=.dockerignore . | wc -c` (before/after context size)
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae947adadc8331bf0358f12d52df37