### PR TITLE
Expand Trivy severity to fail on high vulnerabilities

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}-${{ matrix.service }}:${{ steps.meta.outputs.version }}
-          severity: CRITICAL
+          severity: HIGH,CRITICAL
+          vuln-type: os,library
           exit-code: '1'
 
       - name: Upload SBOM to release


### PR DESCRIPTION
## Summary
- expand Trivy scan severity to `HIGH,CRITICAL`
- add `vuln-type: os,library` for more thorough scans

## Testing
- `pytest`
- `./bin/act -W .github/workflows/docker-publish.yml -j build -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68af31d8ec60833197f552263b9b3abc