### PR TITLE
fix: install dev deps for web build

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,18 +1,26 @@
+######################################################
 # Environment files
 .env
 *.env
 
-# Dependencies and builds
+# Dependencies and build outputs
 node_modules
 dist
 build
 
-# Tests
+# Tests and coverage
 tests
 coverage
 **/.pytest_cache
 
+# Git and docker files
+.git
+.gitignore
+Dockerfile.dev
+Dockerfile.local
+
 # Logs
+npm-debug.log*
 *.log
 
 # IDE and system files

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,19 +4,16 @@
 FROM node:20.11.1-alpine AS build
 WORKDIR /app
 
-ARG NODE_ENV=production
-ENV NODE_ENV=$NODE_ENV
-
-# Install dependencies (use cache efficiently)
+# Install dependencies required for the build
 COPY package.json package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev
+    npm ci
 
-# Copy source and build
+# Copy source files and build the production assets
 COPY . .
 RUN npm run build
 
-# Stage 2: serve with nginx
+# Stage 2: serve the compiled assets with nginx
 FROM nginx:1.27.2-alpine
 COPY --chown=nginx:nginx --from=build /app/dist /usr/share/nginx/html
 USER 101


### PR DESCRIPTION
## Summary
- ensure Vite dev dependencies are installed in web Docker build
- add .dockerignore for web context to keep build lean

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af4383a8e08331892eaa1b6fc81852