### PR TITLE
chore: update code scanning workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  security-events: write
+
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/form-platform
 
@@ -24,13 +28,13 @@ jobs:
             file: web/Dockerfile
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -89,12 +93,12 @@ jobs:
           output: trivy-${{ matrix.service }}.sarif
 
       - name: Upload Trivy results to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-${{ matrix.service }}.sarif
 
       - name: Upload SBOM to release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: sbom-${{ matrix.service }}-${{ steps.meta.outputs.version }}.spdx.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM python:3.11.7-slim AS builder
+FROM python:3.11.9-slim AS builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # Dependencias para compilar paquetes (libffi para bcrypt)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential libffi-dev curl && \
     rm -rf /var/lib/apt/lists/*
 
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 COPY . .
 
-FROM python:3.11.7-slim
+FROM python:3.11.9-slim
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # Dependencias mínimas de runtime
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libffi8 && \
     rm -rf /var/lib/apt/lists/*
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,6 @@ uvicorn[standard]==0.30.6
 python-multipart==0.0.9
 SQLAlchemy==2.0.32
 psycopg2-binary==2.9.9
-python-jose==3.3.0
+python-jose==3.4.0
 passlib[bcrypt]==1.7.4
 pydantic-settings==2.3.4


### PR DESCRIPTION
## Summary
- update SARIF upload to use `github/codeql-action/upload-sarif@v3`
- grant `security-events: write` permission in workflow
- bump checkout, buildx, login, and gh-release actions to latest major versions
- upgrade backend to `python:3.11.9-slim` and apply `apt-get upgrade` for security patches
- bump `python-jose` to `3.4.0` to resolve CVE-2024-33663

## Testing
- `yamllint .github/workflows/docker-publish.yml` *(fails: line-length, document-start, truthy)*
- `./actionlint -color .github/workflows/docker-publish.yml`
- `pip install -r backend/requirements.txt`
- `pytest backend/test_health.py`
- `docker build -t backend-test backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5d8017e48331866a2d93cbd30516