### PR TITLE
fix: improve dev defaults and login error handling

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -44,7 +44,11 @@ JWT_ALG = "HS256"
 ACCESS_TOKEN_EXPIRES_MIN = settings.ACCESS_TOKEN_MIN
 ALLOWED_ORIGINS = [o.strip() for o in settings.ALLOWED_ORIGINS.split(",") if o.strip()]
 
-engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+# When using SQLite in development we need to disable the thread check so that
+# the same connection can be shared across requests. ``connect_args`` is ignored
+# for other database backends.
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, pool_pre_ping=True, connect_args=connect_args)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -4,13 +4,32 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    DATABASE_URL: str
-    JWT_SECRET: str
-    FILES_ROOT: Path = Path("/data")
+    """Application configuration loaded from environment variables.
+
+    Reasonable defaults are provided so the application can run in a
+    development environment without the need for a ``.env`` file.  Each value
+    can still be overridden via the environment when deploying to production.
+    """
+
+    # Default to a local SQLite database so the API can start even if no
+    # DATABASE_URL is supplied.  For production a proper database URL should be
+    # provided via the environment.
+    DATABASE_URL: str = "sqlite:///./local.db"
+
+    # A non-empty JWT secret is required by the app.  Using a deterministic
+    # value helps development but should be overridden in production.
+    JWT_SECRET: str = "dev-secret"
+
+    # Store uploaded files inside the repository by default which makes local
+    # development easier.  docker-compose overrides this with a persistent
+    # volume.
+    FILES_ROOT: Path = Path("./storage")
     MAX_FILE_MB: int = 50
     ALLOWED_EXT: str = "pdf,docx,xlsx,jpg,png,zip"
     ACCESS_TOKEN_MIN: int = 120
-    ALLOWED_ORIGINS: str = ""
+    # Allow the Vite dev server to talk to the API out of the box.  Multiple
+    # origins are comma separated and can be overridden via the environment.
+    ALLOWED_ORIGINS: str = "http://localhost:5173,http://127.0.0.1:5173"
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
 
   api:
     build: ./backend
-    command: uvicorn app:app --host 0.0.0.0 --port 8000 --reload
+    # ENTRYPOINT en la imagen ya ejecuta ``uvicorn app:app``,
+    # por lo que solo se pasan las opciones adicionales aquí.
+    command: ["--host", "0.0.0.0", "--port", "8000", "--reload"]
     environment:
       DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       FILES_ROOT: /data


### PR DESCRIPTION
## Summary
- provide sensible development defaults for backend settings
- allow SQLite connections and handle thread checks
- improve frontend login with safer JSON parsing and a dev API URL
- avoid duplicate uvicorn command in docker-compose so the API container starts properly
- enable localhost CORS so the frontend can reach the API in development

## Testing
- `pytest -q`
- `cd web && npm test >/tmp/npm-test.log && cat /tmp/npm-test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c1eac1787883318713bd5e6b1061ec