### PR TITLE
Project edit/delete + project deletion-request workflow (backend & frontend)

### DIFF
--- a/web/src/DeleteRequestsAdmin.jsx
+++ b/web/src/DeleteRequestsAdmin.jsx
@@ -1,16 +1,21 @@
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
-import { listDeleteRequests, approveDeleteRequest, rejectDeleteRequest } from "./api";
+import { listDeleteRequests, approveDeleteRequest, rejectDeleteRequest, listProjectDeleteRequests, approveProjectDeleteRequest, rejectProjectDeleteRequest } from "./api";
 
 
 
 export default function DeleteRequestsAdmin({ token }) {
     const [items, setItems] = useState([]);
+    const [projectItems, setProjectItems] = useState([]);
 
     async function load() {
         try {
-            const rows = await listDeleteRequests(token);
+            const [rows, projectRows] = await Promise.all([
+                listDeleteRequests(token),
+                listProjectDeleteRequests(token),
+            ]);
             setItems(rows);
+            setProjectItems(projectRows);
         } catch (err) {
             toast.error(err.message || "Error");
         }
@@ -35,6 +40,28 @@ export default function DeleteRequestsAdmin({ token }) {
         if (!window.confirm("¿Rechazar solicitud?")) return;
         try {
             await rejectDeleteRequest(id, token);
+            toast.success("Solicitud rechazada");
+            await load();
+        } catch (err) {
+            toast.error(err.message || "Error");
+        }
+    }
+
+    async function approveProject(id) {
+        if (!window.confirm("¿Aprobar eliminación de proyecto?")) return;
+        try {
+            await approveProjectDeleteRequest(id, token);
+            toast.success("Proyecto eliminado");
+            await load();
+        } catch (err) {
+            toast.error(err.message || "Error");
+        }
+    }
+
+    async function rejectProject(id) {
+        if (!window.confirm("¿Rechazar solicitud de eliminación de proyecto?")) return;
+        try {
+            await rejectProjectDeleteRequest(id, token);
             toast.success("Solicitud rechazada");
             await load();
         } catch (err) {
@@ -84,6 +111,50 @@ export default function DeleteRequestsAdmin({ token }) {
                         <tr>
                             <td className="py-4 text-center text-slate-500" colSpan={5}>
 
+                                No hay solicitudes pendientes.
+                            </td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+
+            <h3 className="text-base font-semibold mt-10 mb-4">Solicitudes de eliminación de proyectos</h3>
+            <table className="min-w-full text-sm">
+                <thead>
+                    <tr className="border-b text-left">
+                        <th className="py-2 pr-3">Proyecto</th>
+                        <th className="py-2 pr-3">Motivo</th>
+                        <th className="py-2 pr-3">Solicitante</th>
+                        <th className="py-2 pr-3">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {projectItems.map((r) => (
+                        <tr key={r.id} className="border-b">
+                            <td className="py-2 pr-3">{r.project?.code || "(sin proyecto)"}</td>
+                            <td className="py-2 pr-3">{r.reason}</td>
+                            <td className="py-2 pr-3">{r.requested_by}</td>
+                            <td className="py-2 pr-3">
+                                <button
+                                    type="button"
+                                    onClick={() => approveProject(r.id)}
+                                    className="mr-2 rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                >
+                                    Aprobar
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => rejectProject(r.id)}
+                                    className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50"
+                                >
+                                    Denegar
+                                </button>
+                            </td>
+                        </tr>
+                    ))}
+                    {projectItems.length === 0 && (
+                        <tr>
+                            <td className="py-4 text-center text-slate-500" colSpan={4}>
                                 No hay solicitudes pendientes.
                             </td>
                         </tr>

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -405,3 +405,74 @@ export async function deleteProjectMember(projectId, userId, token) {
     if (!r.ok) throw new Error(j.detail || "Error eliminando miembro");
     return j;
 }
+
+
+export async function updateProject(projectId, data, token) {
+    const fd = asForm(data);
+    const r = await fetch(`${API}/projects/${projectId}`, {
+        method: "PATCH",
+        headers: authHeaders(token),
+        body: fd,
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "Error actualizando proyecto");
+    return j;
+}
+
+export async function deleteProject(projectId, token) {
+    const r = await fetch(`${API}/projects/${projectId}`, {
+        method: "DELETE",
+        headers: authHeaders(token),
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "Error eliminando proyecto");
+    return j;
+}
+
+export async function requestProjectDelete(projectId, reason, token) {
+    const r = await fetch(`${API}/projects/${projectId}/request-delete`, {
+        method: "POST",
+        headers: { ...authHeaders(token), "Content-Type": "application/x-www-form-urlencoded" },
+        body: asForm({ reason }),
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "No se pudo solicitar la eliminación del proyecto");
+    return j;
+}
+
+export async function listProjectDeleteRequests(token) {
+    const r = await fetch(`${API}/project-delete-requests`, { headers: authHeaders(token) });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.detail || "Error listando solicitudes de proyecto");
+    return j.items || [];
+}
+
+export async function approveProjectDeleteRequest(reqId, token) {
+    const r = await fetch(`${API}/project-delete-requests/${reqId}/approve`, {
+        method: "POST",
+        headers: authHeaders(token),
+    });
+    let j = {};
+    try {
+        j = await r.json();
+    } catch {
+        /* sin cuerpo */
+    }
+    if (!r.ok) throw new Error(j.detail || "Error aprobando solicitud de proyecto");
+    return j;
+}
+
+export async function rejectProjectDeleteRequest(reqId, token) {
+    const r = await fetch(`${API}/project-delete-requests/${reqId}/reject`, {
+        method: "POST",
+        headers: authHeaders(token),
+    });
+    let j = {};
+    try {
+        j = await r.json();
+    } catch {
+        /* sin cuerpo */
+    }
+    if (!r.ok) throw new Error(j.detail || "Error rechazando solicitud de proyecto");
+    return j;
+}


### PR DESCRIPTION
### Motivation
- Permitir que los administradores eliminen proyectos de forma segura y que los colaboradores soliciten la eliminación para que un admin la revise.
- Añadir la posibilidad de editar el nombre de un proyecto desde la UI y ofrecer acciones claras en la lista de proyectos.

### Description
- Se añadió el modelo `ProjectDeleteRequest` y migración segura en `safe_migrate` para crear su tabla si no existe. 
- Se implementó el helper `delete_project_by_id` que limpia registros relacionados en la base de datos y borra la carpeta de archivos del proyecto en disco (`FILES_ROOT/projects/{code}`).
- Nuevos endpoints en `backend/app.py`: `PATCH /projects/{project_id}` para editar nombre, `DELETE /projects/{project_id}` para eliminar (requiere admin), `POST /projects/{project_id}/request-delete` para que un miembro solicite la eliminación, y endpoints admin para listar/aprobar/rechazar solicitudes (`/project-delete-requests`, `/project-delete-requests/{id}/approve`, `/project-delete-requests/{id}/reject`).
- Frontend: se añadieron helpers en `web/src/api.js` (`updateProject`, `deleteProject`, `requestProjectDelete`, `listProjectDeleteRequests`, `approveProjectDeleteRequest`, `rejectProjectDeleteRequest`) y se actualizaron las UIs en `web/src/ProjectAdmin.jsx` (acciones Editar / Eliminar / Solicitar eliminación) y `web/src/DeleteRequestsAdmin.jsx` (nueva tabla para solicitudes de eliminación de proyectos con aprobar/denegar).

### Testing
- Se validó la sintaxis del backend con `python -m py_compile backend/app.py` y la verificación fue exitosa. 
- Se construyó el frontend con `cd web && npm run build` exitosamente. 
- Se intentó capturar una pantalla de la UI con Playwright, pero la petición falló porque no había servidor frontend activo en `127.0.0.1:5173` (NET err `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de9b31fa883319fb37acafe9b9757)